### PR TITLE
Write CLI in ES6

### DIFF
--- a/bin/butane.js
+++ b/bin/butane.js
@@ -1,9 +1,3 @@
 #!/usr/bin/env node
 
-var argv = require('minimist')(process.argv.slice(2));
-var fireRules = require('../dist/');
-
-var input = argv._[0];
-var output = argv._[1];
-
-fireRules.convert(input, output);
+require('require-relative-main')('./cli', __dirname)

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,0 +1,4 @@
+const [input, output] = require('minimist')(process.argv.slice(2))._;
+const fireRules = require('../');
+
+fireRules.convert(input, output);

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "esprima": "2.2.0",
     "js-yaml": "3.3.0",
     "lodash": "3.8.0",
-    "minimist": "1.1.1"
+    "minimist": "1.1.1",
+    "require-relative-main": "^1.1.0"
   },
   "devDependencies": {
     "babel": "5.2.12",


### PR DESCRIPTION
This takes advantage of a technique I've been using for transpiling tools with CLIs. The bin file just requires `'./cli'` relative to the main file and the actually meat of the CLI goes in the `lib/` folder.
