### PR TITLE
Remove explicit install and test commands from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
 language: node_js
 node_js:
 - '0.12'
-install:
-- npm install
-script:
-- npm test


### PR DESCRIPTION
These commands are automatically run if no commands are explicitly defined for install and test
