### PR TITLE
Reintroduce require-relative-main

### DIFF
--- a/bin/butane.js
+++ b/bin/butane.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-require('../dist/cli');
+require('require-relative-main')('./cli', __dirname)

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -2,6 +2,6 @@ const [input, output] = require('minimist')(process.argv.slice(2))._;
 
 const {
   convert
-} = require('./index');
+} = require('./');
 
 convert(input, output);

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "babel-runtime": "5.2.12",
     "chai": "2.3.0",
     "eslint": "0.20.0",
-    "mocha": "2.2.4"
+    "mocha": "2.2.4",
+    "require-relative-main": "~1.1.1"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
I've used a `~` with the dependency rather than pinning it because it's best to trust package maintainers to be good semantic versioners. For every time some upstream legitimately slips a breaking change into a non-major bump, at least 10x will solve some bug that would have affected your users, totally transparently. 

Also, don't `require('./index')`. That's implicit when you require the directory. 
